### PR TITLE
Block recipe delete when it is used in any menu

### DIFF
--- a/src/app/analysis/components/form/recipe-form.test.tsx
+++ b/src/app/analysis/components/form/recipe-form.test.tsx
@@ -183,9 +183,6 @@ describe('recipe-form', () => {
         );
 
         await user.click(screen.getByRole('button', { name: /delete/i }));
-        expect(contextValue.setCurrentRecipe).not.toHaveBeenCalled();
-
-        await user.click(screen.getByRole('button', { name: /delete/i }));
         expect(contextValue.setCurrentRecipe).toHaveBeenCalledWith({id: null, recipe: null, image: null, mode: AnalysisMode.VIEW});
     });
 

--- a/src/app/analysis/components/form/recipe-form.tsx
+++ b/src/app/analysis/components/form/recipe-form.tsx
@@ -1,6 +1,7 @@
 'use client';
-import { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { useRouter} from 'next/navigation';
+import useSWR from 'swr';
 import RecipeCard from '@/app/components/cards/recipe-cards/recipe-card';
 import IngredientSearch from './ingredient-search';
 import ImagePicker from '@/app/components/utilities/image-picker';
@@ -31,6 +32,24 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
     const { setMessage, setStatus, setIsLoading } = useContext(StatusContext);
     const { setScrollBehavior } = useContext(SlideContext);
     const { sendRequest } = useHttpClient();
+    const menusFetcher = ([url, t]: [string, string]) =>
+        fetch(url, { headers: { Authorization: 'Bearer ' + t } }).then(r => (r.ok ? r.json() : { menus: [] }));
+    const { data: menusData } = useSWR(token ? ['/menus', token] : null, menusFetcher);
+    const affectedMenuNames = useMemo<string[]>(() => {
+        if (!currentRecipe.id || !menusData?.menus) return [];
+        const names: string[] = [];
+        for (const menu of menusData.menus) {
+            const recipes = menu?.menu?.recipes ?? [];
+            const hit = recipes.some((r: any) => {
+                const sel = r?.selectedRecipe;
+                if (!sel) return false;
+                if (typeof sel === 'string') return sel === currentRecipe.id;
+                return sel.id === currentRecipe.id || sel._id === currentRecipe.id;
+            });
+            if (hit && menu?.menu?.name) names.push(menu.menu.name);
+        }
+        return names;
+    }, [menusData, currentRecipe.id]);
     const [name, setName] = useState<string>('');
     const [servings, setServings] = useState<number>(1);
     const [ingredients, setIngredients] = useState<StructuredIngredient[]>([]);
@@ -173,12 +192,19 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
     }
 
     const confirmed = () => {
-        if(deleteReady) return true;
+        if (affectedMenuNames.length === 0) return true;
+        if (deleteReady) return true;
 
         setStatus(StatusType.ERROR);
-        setMessage('Menus with this recipe will be modified. If you agree press delete button again');
+        setMessage(`This recipe is in ${formatList(affectedMenuNames)}. Deleting will remove it from them. Press delete again to confirm.`);
         setDeleteReady(true);
         return false;
+    }
+
+    const formatList = (items: string[]): string => {
+        if (items.length === 1) return items[0];
+        if (items.length === 2) return `${items[0]} and ${items[1]}`;
+        return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
     }
 
     const handleNameInput = (e: React.FormEvent<HTMLInputElement>) => {

--- a/src/app/analysis/components/form/recipe-form.tsx
+++ b/src/app/analysis/components/form/recipe-form.tsx
@@ -55,7 +55,6 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
     const [ingredients, setIngredients] = useState<StructuredIngredient[]>([]);
     const [legacyIngredients, setLegacyIngredients] = useState<string[]>([]);
     const [previewUrl, setPreviewUrl] = useState<string | null>(null);
-    const [deleteReady, setDeleteReady] = useState<boolean>(false);
     const router = useRouter();
 
     useEffect(() => {
@@ -171,7 +170,11 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
             setIsLoading(false);
             return;
         }
-        if(!confirmed()) return;
+        if (affectedMenuNames.length > 0) {
+            setStatus(StatusType.ERROR);
+            setMessage(`Recipe is used in menu: ${affectedMenuNames.join(', ')}. Remove it from the menu first.`);
+            return;
+        }
 
         try {
             await sendRequest(
@@ -187,24 +190,7 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
             }, 500);
             setCurrentRecipe({id: null, recipe: null, image: null, mode: AnalysisMode.VIEW});
             setMessage("Recipe deleted successfully");
-            setDeleteReady(false);
         } catch (err) {}
-    }
-
-    const confirmed = () => {
-        if (affectedMenuNames.length === 0) return true;
-        if (deleteReady) return true;
-
-        setStatus(StatusType.ERROR);
-        setMessage(`This recipe is in ${formatList(affectedMenuNames)}. Deleting will remove it from them. Press delete again to confirm.`);
-        setDeleteReady(true);
-        return false;
-    }
-
-    const formatList = (items: string[]): string => {
-        if (items.length === 1) return items[0];
-        if (items.length === 2) return `${items[0]} and ${items[1]}`;
-        return `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`;
     }
 
     const handleNameInput = (e: React.FormEvent<HTMLInputElement>) => {

--- a/src/server/db-controllers/recipe-controllers.js
+++ b/src/server/db-controllers/recipe-controllers.js
@@ -30,9 +30,9 @@ const getAllRecipes = async (req, res, next) => {
     }
 
     res.json({
-        recipe: userWithRecipe.recipes
-            .filter(recipe => !recipe.archived)
-            .map(recipe => recipe.toObject({ getters: true }))
+        recipe: userWithRecipe.recipes.map(recipe =>
+            recipe.toObject({ getters: true })
+        )
     });
 };
 
@@ -97,7 +97,7 @@ const createRecipe = async (req, res, next) => {
 
     let existingRecipe
     try {
-        existingRecipe = await Recipe.findOne({ "recipe.name": parsedRecipe.name, "creator": req.userData.userId, "archived": { $ne: true } });
+        existingRecipe = await Recipe.findOne({ "recipe.name": parsedRecipe.name, "creator": req.userData.userId});
     } catch (err) {
         console.error(err);
         const error = new HttpError(
@@ -202,7 +202,7 @@ const deleteRecipe = async (req, res, next) => {
 
     let recipe;
     try {
-        recipe = await Recipe.findById(recipeId);
+        recipe = await Recipe.findById(recipeId).populate('creator');
     } catch (err) {
         console.error(err);
         const error = new HttpError(
@@ -218,7 +218,7 @@ const deleteRecipe = async (req, res, next) => {
         return next(error);
     }
 
-    if (recipe.creator.toString() !== req.userData.userId) {
+    if (recipe.creator.id !== req.userData.userId) {
         console.error('Not authorized.');
         const error = new HttpError(
             'You are not allowed to delete this recipe.',
@@ -227,9 +227,35 @@ const deleteRecipe = async (req, res, next) => {
         return next(error);
     }
 
-    recipe.archived = true;
+    let userWithMenu;
     try {
-        await recipe.save();
+        userWithMenu = await User.findById(req.userData.userId).populate('menus');
+    } catch (err) {
+        console.error(err);
+        const error = new HttpError('Could not delete recipe. Try again later.', 500);
+        return next(error);
+    }
+
+    const referencingMenus = (userWithMenu?.menus ?? []).filter(menu =>
+        (menu.menu.recipes ?? []).some(r => r.selectedRecipe && r.selectedRecipe.toString() === recipeId)
+    );
+
+    if (referencingMenus.length > 0) {
+        const names = referencingMenus.map(m => m.menu.name).join(', ');
+        const error = new HttpError(
+            `Recipe is used in menu: ${names}. Remove it from the menu first.`,
+            409
+        );
+        return next(error);
+    }
+
+    try {
+        const sess = await mongoose.startSession();
+        sess.startTransaction();
+        await recipe.deleteOne({ session: sess });
+        recipe.creator.recipes.pull(recipe);
+        await recipe.creator.save({ session: sess });
+        await sess.commitTransaction();
     } catch (err) {
         console.error(err);
         const error = new HttpError(
@@ -237,6 +263,14 @@ const deleteRecipe = async (req, res, next) => {
             500
         );
         return next(error);
+    }
+
+    if(recipe.imageName) {
+        try {
+            await gcpStorage.deleteImage(recipe.imageName);
+        } catch(err) {
+            return next(err);
+        }
     }
 
     res.status(200).json({ message: 'Deleted recipe.' });

--- a/src/server/db-controllers/recipe-controllers.js
+++ b/src/server/db-controllers/recipe-controllers.js
@@ -30,9 +30,9 @@ const getAllRecipes = async (req, res, next) => {
     }
 
     res.json({
-        recipe: userWithRecipe.recipes.map(recipe =>
-            recipe.toObject({ getters: true })
-        )
+        recipe: userWithRecipe.recipes
+            .filter(recipe => !recipe.archived)
+            .map(recipe => recipe.toObject({ getters: true }))
     });
 };
 
@@ -97,7 +97,7 @@ const createRecipe = async (req, res, next) => {
 
     let existingRecipe
     try {
-        existingRecipe = await Recipe.findOne({ "recipe.name": parsedRecipe.name, "creator": req.userData.userId});
+        existingRecipe = await Recipe.findOne({ "recipe.name": parsedRecipe.name, "creator": req.userData.userId, "archived": { $ne: true } });
     } catch (err) {
         console.error(err);
         const error = new HttpError(
@@ -202,7 +202,7 @@ const deleteRecipe = async (req, res, next) => {
 
     let recipe;
     try {
-        recipe = await Recipe.findById(recipeId).populate('creator');
+        recipe = await Recipe.findById(recipeId);
     } catch (err) {
         console.error(err);
         const error = new HttpError(
@@ -218,7 +218,7 @@ const deleteRecipe = async (req, res, next) => {
         return next(error);
     }
 
-    if (recipe.creator.id !== req.userData.userId) {
+    if (recipe.creator.toString() !== req.userData.userId) {
         console.error('Not authorized.');
         const error = new HttpError(
             'You are not allowed to delete this recipe.',
@@ -227,13 +227,9 @@ const deleteRecipe = async (req, res, next) => {
         return next(error);
     }
 
+    recipe.archived = true;
     try {
-        const sess = await mongoose.startSession();
-        sess.startTransaction();
-        await recipe.deleteOne({ session: sess });
-        recipe.creator.recipes.pull(recipe);
-        await recipe.creator.save({ session: sess });
-        await sess.commitTransaction();
+        await recipe.save();
     } catch (err) {
         console.error(err);
         const error = new HttpError(
@@ -243,58 +239,8 @@ const deleteRecipe = async (req, res, next) => {
         return next(error);
     }
 
-    if(recipe.imageName) {
-        try {
-            await gcpStorage.deleteImage(recipe.imageName);
-        } catch(err) {
-            return next(err);
-        }
-    }
-
-    try {
-        await modifyMenus(recipeId, recipe.creator);
-    } catch(err) {
-        console.error(err);
-        const error = new HttpError(
-            'Could not modify menu. Try again later.',
-            500
-        );
-        return next(error);
-    }
-
     res.status(200).json({ message: 'Deleted recipe.' });
 };
-
-const modifyMenus = async(recipeId, user) => {
-    let userWithMenu;
-    try {
-        userWithMenu = await User.findById(user.id).populate('menus');
-    } catch (err) {
-        throw new HttpError('Could not find menu. Try again later.', 500);
-    }
-
-    if (!userWithMenu) {
-        throw new HttpError('Could not find menu. Try again later.', 404);
-    }
-
-    for (const menu of userWithMenu.menus) {
-        menu.menu.recipes = menu.menu.recipes.filter(recipe => recipe.selectedRecipe != recipeId);
-        const ingredients = menu.menu.ingredients;
-        const ingredientsEmpty = !ingredients || ingredients.length === 0;
-        if (menu.menu.recipes.length === 0 && ingredientsEmpty) {
-            console.log('empty menu');
-            const sess = await mongoose.startSession();
-            sess.startTransaction();
-            await menu.deleteOne({ session: sess });
-            user.menus.pull(menu);
-            await user.save({ session: sess });
-            await sess.commitTransaction();
-        } else {
-            menu.markModified('menu');
-            await menu.save();
-        }
-    }
-}
 
 exports.getAllRecipes = getAllRecipes;
 exports.getRecipesById = getRecipesById;

--- a/src/server/models/recipe.js
+++ b/src/server/models/recipe.js
@@ -57,7 +57,6 @@ const recipeSchema = new Schema({
     },
     image: { type: String, required: false },
     imageName: { type: String, required: false },
-    archived: { type: Boolean, default: false },
     creator: { type: mongoose.Types.ObjectId, required: true, ref: 'User'}
 });
 

--- a/src/server/models/recipe.js
+++ b/src/server/models/recipe.js
@@ -57,6 +57,7 @@ const recipeSchema = new Schema({
     },
     image: { type: String, required: false },
     imageName: { type: String, required: false },
+    archived: { type: Boolean, default: false },
     creator: { type: mongoose.Types.ObjectId, required: true, ref: 'User'}
 });
 


### PR DESCRIPTION
## Summary

- **Backend**: ``deleteRecipe`` now checks whether any of the user's menus reference the recipe. If yes → 409 with the menu name(s). If no → hard-delete the document, pull from ``user.recipes``, and delete the image from Firebase Storage.
- **Frontend**: ``recipe-form`` checks the SWR-cached menus. If the recipe is in any menu → error toast \`Recipe is used in menu: X. Remove it from the menu first.\` and no request is sent. Otherwise → delete on a single click (matches the food/menu delete UX).
- Reverted the archived field, the archived filter in ``getAllRecipes``, and the archived-aware duplicate check in ``createRecipe`` — with the block-in-use rule, menus are always safe, so soft-delete isn't needed.

## Restore of previously-archived recipe

The "Quinoa with chicken breast and tomato" recipe was soft-archived under the earlier iteration of this branch. Once this PR ships, the ``getAllRecipes`` filter is gone, so the recipe reappears in the library automatically — no manual restore step needed.

## Test plan

- [x] ``npm test`` — 47 suites / 119 tests
- [ ] Preview: recipe not in any menu → single-click delete succeeds
- [ ] Preview: recipe in a menu → toast \`Recipe is used in menu: X. Remove it from the menu first.\`, no delete happens
- [ ] Preview: "Quinoa with chicken breast and tomato" is back in the library after the redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)