### PR TITLE
Polish A: password strength, error boundary, multer fix

### DIFF
--- a/src/app/auth/basic_auth/page.module.css
+++ b/src/app/auth/basic_auth/page.module.css
@@ -90,6 +90,26 @@
     background-color: var(--primary-light-color);
 }
 
+.password_strength {
+    font-size: 0.7rem;
+    font-weight: 600;
+    margin-top: 0.35rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.strength_weak {
+    color: #c62828;
+}
+
+.strength_medium {
+    color: #ef6c00;
+}
+
+.strength_strong {
+    color: #2e7d32;
+}
+
 @media screen and (max-width: 500px) {
     .container {
         height: 100%;

--- a/src/app/auth/basic_auth/page.tsx
+++ b/src/app/auth/basic_auth/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useContext, useEffect, useRef } from 'react';
+import { useState, useContext, useEffect, useMemo, useRef } from 'react';
 import { useRouter} from 'next/navigation';
 import AuthMenu from '@/app/components/navigation/menus/auth-menu';
 import NavBar from '@/app/components/navigation/nav-bar';
@@ -17,9 +17,23 @@ const Auth = (): JSX.Element => {
     const { setScrollBehavior, slide } = useContext(SlideContext);
     const { login, token } = useContext(AuthContext);
     const [loginMode, setLoginMode] = useState<boolean>(true);
+    const [password, setPassword] = useState<string>('');
     const { setMessage } = useContext(StatusContext);
     const router = useRouter();
     const shouldNavigate = useRef(false);
+
+    const passwordStrength = useMemo(() => {
+        if (loginMode) return null;
+        const hasLen = password.length >= 8;
+        const hasLetter = /[A-Za-z]/.test(password);
+        const hasNumber = /[0-9]/.test(password);
+        const hasSymbol = /[^A-Za-z0-9]/.test(password);
+        const score = [hasLen, hasLetter, hasNumber, hasSymbol].filter(Boolean).length;
+        if (password.length === 0) return null;
+        if (score <= 2) return { label: 'Weak', level: 'weak' as const };
+        if (score === 3) return { label: 'Medium', level: 'medium' as const };
+        return { label: 'Strong', level: 'strong' as const };
+    }, [password, loginMode]);
 
     useEffect(() => {
         if (!token || !shouldNavigate.current) return;
@@ -95,7 +109,19 @@ const Auth = (): JSX.Element => {
                     </div>
                     <div className={styles.form_group}>
                         <label htmlFor="password">Password</label>
-                        <input id="password" type="password" minLength={5} required/>
+                        <input
+                            id="password"
+                            type="password"
+                            minLength={loginMode ? undefined : 8}
+                            required
+                            value={password}
+                            onChange={e => setPassword(e.currentTarget.value)}
+                        />
+                        {passwordStrength && (
+                            <div className={`${styles.password_strength} ${styles[`strength_${passwordStrength.level}`]}`}>
+                                {passwordStrength.label}
+                            </div>
+                        )}
                     </div>
                     <div className={styles.form_group}>
                         <button type="submit">{loginMode ? 'Login' : 'Signup'}</button>

--- a/src/app/error.module.css
+++ b/src/app/error.module.css
@@ -1,0 +1,71 @@
+.container {
+    min-height: 100dvh;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+}
+
+.card {
+    max-width: 420px;
+    width: 100%;
+    padding: 2rem;
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.55);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    box-shadow: var(--shadow-lg);
+    text-align: center;
+}
+
+.title {
+    margin: 0 0 0.5rem;
+    font-size: 1.25rem;
+    color: #222;
+}
+
+.message {
+    margin: 0 0 1.5rem;
+    font-size: 0.9rem;
+    color: #555;
+    line-height: 1.4;
+}
+
+.actions {
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.primary,
+.secondary {
+    height: 2.5rem;
+    padding: 0 1.25rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color var(--transition);
+}
+
+.primary {
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+}
+
+.primary:hover {
+    background-color: var(--primary-darker-color);
+}
+
+.secondary {
+    background-color: white;
+    border: 1px solid var(--primary-color);
+    color: var(--primary-color);
+}
+
+.secondary:hover {
+    background-color: var(--primary-light-color);
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useEffect } from 'react';
+import styles from './error.module.css';
+
+interface ErrorPageProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+const ErrorPage = ({ error, reset }: ErrorPageProps): JSX.Element => {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <div className={styles.container}>
+            <div className={styles.card}>
+                <h2 className={styles.title}>Something went wrong</h2>
+                <p className={styles.message}>
+                    We hit an unexpected error. Try again, or reload the page.
+                </p>
+                <div className={styles.actions}>
+                    <button className={styles.primary} onClick={reset}>Try again</button>
+                    <button className={styles.secondary} onClick={() => location.reload()}>Reload page</button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ErrorPage;

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect } from 'react';
+
+interface GlobalErrorProps {
+    error: Error & { digest?: string };
+    reset: () => void;
+}
+
+const GlobalError = ({ error, reset }: GlobalErrorProps): JSX.Element => {
+    useEffect(() => {
+        console.error(error);
+    }, [error]);
+
+    return (
+        <html lang="en">
+            <body style={{
+                minHeight: '100dvh',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '1rem',
+                fontFamily: 'system-ui, sans-serif',
+                textAlign: 'center',
+            }}>
+                <div style={{ maxWidth: 420 }}>
+                    <h2 style={{ marginBottom: '0.5rem' }}>Something went wrong</h2>
+                    <p style={{ margin: '0 0 1.5rem', color: '#555' }}>
+                        A critical error occurred. Try reloading the page.
+                    </p>
+                    <button
+                        style={{
+                            height: '2.5rem',
+                            padding: '0 1.25rem',
+                            border: 'none',
+                            borderRadius: 6,
+                            background: '#333',
+                            color: 'white',
+                            fontWeight: 600,
+                            cursor: 'pointer',
+                        }}
+                        onClick={reset}
+                    >
+                        Try again
+                    </button>
+                </div>
+            </body>
+        </html>
+    );
+};
+
+export default GlobalError;

--- a/src/server/db-controllers/users-controllers.js
+++ b/src/server/db-controllers/users-controllers.js
@@ -8,9 +8,10 @@ const signup = async (req, res, next) => {
 
     const errors = validationResult(req);
     if (!errors.isEmpty()) {
-        console.error('Validation failed.');
+        console.error('Validation failed.', errors.array());
+        const first = errors.array()[0];
         return next(
-        new HttpError('Invalid inputs passed, please check your data.', 422)
+            new HttpError(first?.msg || 'Invalid inputs passed, please check your data.', 422)
         );
     }
 

--- a/src/server/middleware/multer.js
+++ b/src/server/middleware/multer.js
@@ -18,7 +18,7 @@ const all = async (req, res, next) => {
 
     busboy.on('file', (fieldname, file, {filename, mimeType}) => {
         console.log(`Processed file ${filename}`);
-        dataContainer = {};
+        const dataContainer = {};
 
         file.on('data', (data) => {
             if (!dataContainer.data) {

--- a/src/server/routes/users-routes.js
+++ b/src/server/routes/users-routes.js
@@ -14,7 +14,10 @@ router.post(
         check('email')
         .normalizeEmail()
         .isEmail(),
-        check('password').isLength({ min: 5 })
+        check('password')
+            .isLength({ min: 8 }).withMessage('Password must be at least 8 characters.')
+            .matches(/[A-Za-z]/).withMessage('Password must contain a letter.')
+            .matches(/[0-9]/).withMessage('Password must contain a number.')
     ], 
     usersController.signup
 );


### PR DESCRIPTION
## Summary

- **Password minimum**: 5 → 8 characters, must contain a letter and a number. Server-validated (express-validator on ``/users/signup``); the first validation error is now surfaced in the 422 body so the auth form can show a real reason.
- **Password strength meter**: signup screen shows Weak/Medium/Strong under the password field as the user types.
- **Error boundary**: ``src/app/error.tsx`` catches route-level errors, ``src/app/global-error.tsx`` catches errors in the root layout itself. Both render a friendly card with retry/reload actions instead of a blank page.
- **Multer leak fix**: ``src/server/middleware/multer.js`` was assigning ``dataContainer = {}`` without a declarator, making it a global under concurrent uploads. Now ``const dataContainer``.

## Test plan

- [x] ``npm test`` — 47 suites / 119 tests
- [ ] Preview: signup with a 5-char password → rejected with a clear reason
- [ ] Preview: signup with 8+ chars but only letters → rejected ("must contain a number")
- [ ] Preview: signup with 8+ chars + letters + numbers → succeeds; strength badge shows Medium (add a symbol for Strong)
- [ ] Preview: login flow unchanged (existing short passwords still work — login route is unchanged)
- [ ] Preview: throw a test error inside a page → error card renders, "Try again" resets, "Reload" reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)