### PR TITLE
Polish C: skeletons, empty states, image upload spinner

### DIFF
--- a/src/app/analysis/components/form/form.module.css
+++ b/src/app/analysis/components/form/form.module.css
@@ -525,6 +525,30 @@
     background: rgba(0, 0, 0, 0.7);
 }
 
+.image_preview_overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 2;
+    border-radius: inherit;
+}
+
+@keyframes image_preview_spin {
+    to { transform: rotate(360deg); }
+}
+
+.image_preview_spinner {
+    width: 2.5rem;
+    height: 2.5rem;
+    border: 3px solid rgba(255, 255, 255, 0.35);
+    border-top-color: white;
+    border-radius: 50%;
+    animation: image_preview_spin 0.9s linear infinite;
+}
+
 .form_container_wide {
     max-width: 760px;
 }

--- a/src/app/analysis/components/form/menu-form.tsx
+++ b/src/app/analysis/components/form/menu-form.tsx
@@ -32,7 +32,7 @@ const MenuForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, setI
     const { token } = useContext(AuthContext);
     const { cardOpen, setCardOpen } = useContext(CardOpenContext);
     const { currentMenu, setCurrentMenu } = useContext(CurrentMenuContext);
-    const { setMessage, setStatus, setAction } = useContext(StatusContext);
+    const { setMessage, setStatus, setAction, isLoading } = useContext(StatusContext);
     const { setScrollBehavior } = useContext(SlideContext);
     const { sendRequest } = useHttpClient();
     const [name, setName] = useState<string>('');
@@ -273,6 +273,11 @@ const MenuForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, setI
                         <div className={styles.image_preview}>
                             <img src={previewUrl} alt="preview" />
                             <button type="button" className={styles.image_preview_change} onClick={() => { setPreviewUrl(null); setFile(null); setImageUrl(null); }}>✕</button>
+                            {isLoading && (
+                                <div className={styles.image_preview_overlay} aria-label="Uploading">
+                                    <div className={styles.image_preview_spinner} />
+                                </div>
+                            )}
                         </div>
                     ) : (
                         <ImagePicker

--- a/src/app/analysis/components/form/recipe-form.tsx
+++ b/src/app/analysis/components/form/recipe-form.tsx
@@ -29,7 +29,7 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
     const { token } = useContext(AuthContext);
     const { cardOpen, setCardOpen } = useContext(CardOpenContext);
     const { currentRecipe, setCurrentRecipe } = useContext(CurrentRecipeContext);
-    const { setMessage, setStatus, setIsLoading, setAction } = useContext(StatusContext);
+    const { setMessage, setStatus, setIsLoading, setAction, isLoading } = useContext(StatusContext);
     const { setScrollBehavior } = useContext(SlideContext);
     const { sendRequest } = useHttpClient();
     const menusFetcher = ([url, t]: [string, string]) =>
@@ -266,6 +266,11 @@ const RecipeForm = ({ searchCleared, setClearSearch, file, setFile, imageUrl, se
                         <div className={styles.image_preview}>
                             <img src={previewUrl} alt="preview" />
                             <button type="button" aria-label="Change image" className={styles.image_preview_change} onClick={() => { setPreviewUrl(null); setFile(null); setImageUrl(null); }}>✕</button>
+                            {isLoading && (
+                                <div className={styles.image_preview_overlay} aria-label="Uploading">
+                                    <div className={styles.image_preview_spinner} />
+                                </div>
+                            )}
                         </div>
                     ) : (
                         <ImagePicker

--- a/src/app/components/slider/slide-states.module.css
+++ b/src/app/components/slider/slide-states.module.css
@@ -1,0 +1,86 @@
+.skeleton {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 1rem;
+}
+
+@keyframes skeleton_shimmer {
+    0% { background-position: -180px 0; }
+    100% { background-position: 180px 0; }
+}
+
+.skeleton_title,
+.skeleton_col {
+    background: linear-gradient(
+        90deg,
+        rgba(255, 255, 255, 0.25) 0%,
+        rgba(255, 255, 255, 0.55) 50%,
+        rgba(255, 255, 255, 0.25) 100%
+    );
+    background-size: 360px 100%;
+    border-radius: var(--radius-sm);
+    animation: skeleton_shimmer 1.4s linear infinite;
+}
+
+.skeleton_title {
+    height: 1.25rem;
+    width: 70%;
+}
+
+.skeleton_row {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+}
+
+.skeleton_col {
+    flex: 1;
+    height: 2.25rem;
+}
+
+.empty_wrap {
+    grid-column: 1 / -1;
+    display: flex;
+    justify-content: center;
+    padding: 3rem 1rem;
+}
+
+.empty_card {
+    max-width: 420px;
+    width: 100%;
+    padding: 2rem 1.5rem;
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.45);
+    backdrop-filter: blur(12px);
+    -webkit-backdrop-filter: blur(12px);
+    border: 1px solid rgba(255, 255, 255, 0.55);
+    box-shadow: var(--shadow-md);
+    text-align: center;
+}
+
+.empty_message {
+    margin: 0 0 1.25rem;
+    font-size: 0.95rem;
+    color: #444;
+    line-height: 1.5;
+}
+
+.empty_cta {
+    display: inline-block;
+    padding: 0.65rem 1.4rem;
+    border-radius: var(--radius-sm);
+    background: var(--primary-color);
+    color: white;
+    font-size: 0.85rem;
+    font-weight: 600;
+    text-decoration: none;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    transition: background var(--transition);
+}
+
+.empty_cta:hover {
+    background: var(--primary-darker-color);
+}

--- a/src/app/components/slider/slide-states.module.css
+++ b/src/app/components/slider/slide-states.module.css
@@ -6,22 +6,16 @@
     padding: 1rem;
 }
 
-@keyframes skeleton_shimmer {
-    0% { background-position: -180px 0; }
-    100% { background-position: 180px 0; }
+@keyframes skeleton_pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
 }
 
 .skeleton_title,
 .skeleton_col {
-    background: linear-gradient(
-        90deg,
-        rgba(255, 255, 255, 0.25) 0%,
-        rgba(255, 255, 255, 0.55) 50%,
-        rgba(255, 255, 255, 0.25) 100%
-    );
-    background-size: 360px 100%;
+    background: rgba(0, 0, 0, 0.1);
     border-radius: var(--radius-sm);
-    animation: skeleton_shimmer 1.4s linear infinite;
+    animation: skeleton_pulse 1.4s ease-in-out infinite;
 }
 
 .skeleton_title {

--- a/src/app/components/slider/slide-states.tsx
+++ b/src/app/components/slider/slide-states.tsx
@@ -1,6 +1,18 @@
+'use client';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import cardStyles from '@/app/components/cards/card.module.css';
 import styles from './slide-states.module.css';
+
+export const useMinimumSkeletonTime = (initiallyReady: boolean, ms = 500): boolean => {
+    const [elapsed, setElapsed] = useState(initiallyReady);
+    useEffect(() => {
+        if (elapsed) return;
+        const t = setTimeout(() => setElapsed(true), ms);
+        return () => clearTimeout(t);
+    }, []);
+    return elapsed;
+};
 
 export const SkeletonCard = (): JSX.Element => (
     <div className={cardStyles.placeholder}>

--- a/src/app/components/slider/slide-states.tsx
+++ b/src/app/components/slider/slide-states.tsx
@@ -1,0 +1,31 @@
+import Link from 'next/link';
+import cardStyles from '@/app/components/cards/card.module.css';
+import styles from './slide-states.module.css';
+
+export const SkeletonCard = (): JSX.Element => (
+    <div className={cardStyles.placeholder}>
+        <div className={`${cardStyles.card} ${styles.skeleton}`}>
+            <div className={styles.skeleton_title} />
+            <div className={styles.skeleton_row}>
+                <div className={styles.skeleton_col} />
+                <div className={styles.skeleton_col} />
+                <div className={styles.skeleton_col} />
+            </div>
+        </div>
+    </div>
+);
+
+interface EmptyStateProps {
+    message: string;
+    cta: string;
+    search: string;
+}
+
+export const EmptyState = ({ message, cta, search }: EmptyStateProps): JSX.Element => (
+    <div className={styles.empty_wrap}>
+        <div className={styles.empty_card}>
+            <p className={styles.empty_message}>{message}</p>
+            <Link href={`/${search}`} className={styles.empty_cta}>{cta}</Link>
+        </div>
+    </div>
+);

--- a/src/app/components/slider/slides/food-slide.tsx
+++ b/src/app/components/slider/slides/food-slide.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import FoodCard from '../../cards/food-cards/food-card';
 import Slide from './slide';
-import { SkeletonCard, EmptyState } from '../slide-states';
+import { SkeletonCard, EmptyState, useMinimumSkeletonTime } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedFood } from '@/app/types/types';
 
@@ -20,10 +20,12 @@ const fetcher = ([url, token]: [string, string]) =>
 const FoodSlide = ({ foodDeleted }: FoodSlideProps): JSX.Element => {
     const { token } = useContext(AuthContext);
     const { data, isLoading } = useSWR(token ? ['/foods', token, foodDeleted] : null, fetcher);
+    const minSkeletonElapsed = useMinimumSkeletonTime(!!data);
 
     const foods: LoadedFood[] = data?.foods ?? [];
-    const showSkeletons = !!token && (isLoading || (!data && foods.length === 0));
-    const showEmpty = !!token && !isLoading && !!data && foods.length === 0;
+    const stillLoading = isLoading || !data || !minSkeletonElapsed;
+    const showSkeletons = !!token && stillLoading;
+    const showEmpty = !!token && !stillLoading && foods.length === 0;
 
     return (
         <Slide>

--- a/src/app/components/slider/slides/food-slide.tsx
+++ b/src/app/components/slider/slides/food-slide.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import FoodCard from '../../cards/food-cards/food-card';
 import Slide from './slide';
+import { SkeletonCard, EmptyState } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedFood } from '@/app/types/types';
 
@@ -18,16 +19,26 @@ const fetcher = ([url, token]: [string, string]) =>
 
 const FoodSlide = ({ foodDeleted }: FoodSlideProps): JSX.Element => {
     const { token } = useContext(AuthContext);
-    const { data } = useSWR(token ? ['/foods', token, foodDeleted] : null, fetcher);
+    const { data, isLoading } = useSWR(token ? ['/foods', token, foodDeleted] : null, fetcher);
 
-    const foodList = data?.foods?.map((food: LoadedFood, index: number) => (
-        <FoodCard food={food.food} index={index + 1} key={index + 1} id={food.id} open={false}/>
-    )) ?? [];
+    const foods: LoadedFood[] = data?.foods ?? [];
+    const showSkeletons = !!token && (isLoading || (!data && foods.length === 0));
+    const showEmpty = !!token && !isLoading && !!data && foods.length === 0;
 
     return (
         <Slide>
-            {foodList.length > 0 && foodList}
-            <Button search={'analysis/food-analysis'}/>
+            {showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
+            {!showSkeletons && foods.map((food, index) => (
+                <FoodCard food={food.food} index={index + 1} key={index + 1} id={food.id} open={false}/>
+            ))}
+            {showEmpty && (
+                <EmptyState
+                    message="No foods yet. Analyze an ingredient and save it to your library."
+                    cta="Add your first food"
+                    search="analysis/food-analysis"
+                />
+            )}
+            {!showEmpty && <Button search={'analysis/food-analysis'}/>}
         </Slide>
     );
 }

--- a/src/app/components/slider/slides/menu-slide.tsx
+++ b/src/app/components/slider/slides/menu-slide.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import MenuCard from '../../cards/menu-cards/menu-card';
 import Slide from './slide';
+import { SkeletonCard, EmptyState } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedMenu, RecipeWithServings, Recipe } from '@/app/types/types';
 
@@ -14,9 +15,13 @@ const fetcher = ([url, token]: [string, string]) =>
 
 const MenuSlide = (): JSX.Element => {
     const { token } = useContext(AuthContext);
-    const { data } = useSWR(token ? ['/menus', token] : null, fetcher);
+    const { data, isLoading } = useSWR(token ? ['/menus', token] : null, fetcher);
 
-    const menuList = data?.menus?.map((menu: any, index: number) => {
+    const rawMenus: any[] = data?.menus ?? [];
+    const showSkeletons = !!token && (isLoading || (!data && rawMenus.length === 0));
+    const showEmpty = !!token && !isLoading && !!data && rawMenus.length === 0;
+
+    const menuList = rawMenus.map((menu: any, index: number) => {
         const recipes: RecipeWithServings[] = (menu.menu.recipes ?? [])
             .filter((r: any) => {
                 if (!r.selectedRecipe || typeof r.selectedRecipe === 'string') return false;
@@ -45,12 +50,20 @@ const MenuSlide = (): JSX.Element => {
         return (
             <MenuCard menu={loaded.menu} index={index + 1} key={index + 1} id={loaded.id} image={loaded.image} open={false}/>
         );
-    }) ?? [];
+    });
 
     return (
         <Slide>
-            {menuList.length > 0 && menuList}
-            <Button search={'analysis/menu-analysis'}/>
+            {showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
+            {!showSkeletons && menuList}
+            {showEmpty && (
+                <EmptyState
+                    message="No menus yet. Group recipes into a menu to plan your meals."
+                    cta="Create your first menu"
+                    search="analysis/menu-analysis"
+                />
+            )}
+            {!showEmpty && <Button search={'analysis/menu-analysis'}/>}
         </Slide>
     );
 }

--- a/src/app/components/slider/slides/menu-slide.tsx
+++ b/src/app/components/slider/slides/menu-slide.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import MenuCard from '../../cards/menu-cards/menu-card';
 import Slide from './slide';
-import { SkeletonCard, EmptyState } from '../slide-states';
+import { SkeletonCard, EmptyState, useMinimumSkeletonTime } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedMenu, RecipeWithServings, Recipe } from '@/app/types/types';
 
@@ -16,10 +16,12 @@ const fetcher = ([url, token]: [string, string]) =>
 const MenuSlide = (): JSX.Element => {
     const { token } = useContext(AuthContext);
     const { data, isLoading } = useSWR(token ? ['/menus', token] : null, fetcher);
+    const minSkeletonElapsed = useMinimumSkeletonTime(!!data);
 
     const rawMenus: any[] = data?.menus ?? [];
-    const showSkeletons = !!token && (isLoading || (!data && rawMenus.length === 0));
-    const showEmpty = !!token && !isLoading && !!data && rawMenus.length === 0;
+    const stillLoading = isLoading || !data || !minSkeletonElapsed;
+    const showSkeletons = !!token && stillLoading;
+    const showEmpty = !!token && !stillLoading && rawMenus.length === 0;
 
     const menuList = rawMenus.map((menu: any, index: number) => {
         const recipes: RecipeWithServings[] = (menu.menu.recipes ?? [])

--- a/src/app/components/slider/slides/recipe-slide.tsx
+++ b/src/app/components/slider/slides/recipe-slide.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import RecipeCard from '../../cards/recipe-cards/recipe-card';
 import Slide from './slide';
-import { SkeletonCard, EmptyState } from '../slide-states';
+import { SkeletonCard, EmptyState, useMinimumSkeletonTime } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedRecipe } from '@/app/types/types';
 
@@ -16,10 +16,12 @@ const fetcher = ([url, token]: [string, string]) =>
 const RecipeSlide = (): JSX.Element => {
     const { token } = useContext(AuthContext);
     const { data, isLoading } = useSWR(token ? ['/recipes', token] : null, fetcher);
+    const minSkeletonElapsed = useMinimumSkeletonTime(!!data);
 
     const recipes: LoadedRecipe[] = data?.recipe ?? [];
-    const showSkeletons = !!token && (isLoading || (!data && recipes.length === 0));
-    const showEmpty = !!token && !isLoading && !!data && recipes.length === 0;
+    const stillLoading = isLoading || !data || !minSkeletonElapsed;
+    const showSkeletons = !!token && stillLoading;
+    const showEmpty = !!token && !stillLoading && recipes.length === 0;
 
     return (
         <Slide>

--- a/src/app/components/slider/slides/recipe-slide.tsx
+++ b/src/app/components/slider/slides/recipe-slide.tsx
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import RecipeCard from '../../cards/recipe-cards/recipe-card';
 import Slide from './slide';
+import { SkeletonCard, EmptyState } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedRecipe } from '@/app/types/types';
 
@@ -14,16 +15,26 @@ const fetcher = ([url, token]: [string, string]) =>
 
 const RecipeSlide = (): JSX.Element => {
     const { token } = useContext(AuthContext);
-    const { data } = useSWR(token ? ['/recipes', token] : null, fetcher);
+    const { data, isLoading } = useSWR(token ? ['/recipes', token] : null, fetcher);
 
-    const recipeList = data?.recipe?.map((recipe: LoadedRecipe, index: number) => (
-        <RecipeCard recipe={recipe.recipe} image={recipe.image && `${recipe.image}`} index={index + 1} key={index + 1} id={recipe.id} open={false}/>
-    )) ?? [];
+    const recipes: LoadedRecipe[] = data?.recipe ?? [];
+    const showSkeletons = !!token && (isLoading || (!data && recipes.length === 0));
+    const showEmpty = !!token && !isLoading && !!data && recipes.length === 0;
 
     return (
         <Slide>
-            {recipeList.length > 0 && recipeList}
-            <Button search={'analysis/recipe-analysis'}/>
+            {showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
+            {!showSkeletons && recipes.map((recipe, index) => (
+                <RecipeCard recipe={recipe.recipe} image={recipe.image && `${recipe.image}`} index={index + 1} key={index + 1} id={recipe.id} open={false}/>
+            ))}
+            {showEmpty && (
+                <EmptyState
+                    message="No recipes yet. Combine ingredients into a recipe you can reuse."
+                    cta="Create your first recipe"
+                    search="analysis/recipe-analysis"
+                />
+            )}
+            {!showEmpty && <Button search={'analysis/recipe-analysis'}/>}
         </Slide>
     );
 }


### PR DESCRIPTION
## Summary

- **Loading skeletons** — food/recipe/menu slides render 6 shimmering placeholder cards while SWR is fetching the list. Before this, the slide was blank until data arrived.
- **Empty states** — when the fetched list is empty, show a card explaining what to do next with a call-to-action button that jumps to the analysis page. The '+ Add' tile is hidden in this state so there's only one CTA.
- **Image upload spinner** — while any request is in flight, the image preview in recipe-form and menu-form gets a semi-transparent overlay with a spinner so large image uploads don't feel frozen.

New: ``src/app/components/slider/slide-states.tsx`` exports ``SkeletonCard`` and ``EmptyState`` used by all three slides.

## Test plan

- [x] ``npm test`` — 47 suites / 119 tests
- [ ] Preview: sign in on a fresh account → each tab shows shimmering skeletons briefly, then the empty state card
- [ ] Preview: click the CTA on the empty state → jumps to the correct analysis page
- [ ] Preview: existing account with data → skeletons show briefly, then real cards
- [ ] Preview: save a recipe or menu with a large image → spinner overlays the preview while uploading

🤖 Generated with [Claude Code](https://claude.com/claude-code)