### PR TITLE
Pre-login prompt: 'Sign in to see your foods/recipes/menus'

### DIFF
--- a/src/app/components/slider/slide-states.tsx
+++ b/src/app/components/slider/slide-states.tsx
@@ -41,3 +41,16 @@ export const EmptyState = ({ message, cta, search }: EmptyStateProps): JSX.Eleme
         </div>
     </div>
 );
+
+interface SignInPromptProps {
+    kind: 'foods' | 'recipes' | 'menus';
+}
+
+export const SignInPrompt = ({ kind }: SignInPromptProps): JSX.Element => (
+    <div className={styles.empty_wrap}>
+        <div className={styles.empty_card}>
+            <p className={styles.empty_message}>Sign in to see your {kind}.</p>
+            <Link href="/auth/basic_auth" className={styles.empty_cta}>Sign in</Link>
+        </div>
+    </div>
+);

--- a/src/app/components/slider/slides/food-slide.tsx
+++ b/src/app/components/slider/slides/food-slide.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import FoodCard from '../../cards/food-cards/food-card';
 import Slide from './slide';
-import { SkeletonCard, EmptyState, useMinimumSkeletonTime } from '../slide-states';
+import { SkeletonCard, EmptyState, SignInPrompt, useMinimumSkeletonTime } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedFood } from '@/app/types/types';
 
@@ -29,18 +29,19 @@ const FoodSlide = ({ foodDeleted }: FoodSlideProps): JSX.Element => {
 
     return (
         <Slide>
-            {showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
-            {!showSkeletons && foods.map((food, index) => (
+            {!token && <SignInPrompt kind="foods" />}
+            {token && showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
+            {token && !showSkeletons && foods.map((food, index) => (
                 <FoodCard food={food.food} index={index + 1} key={index + 1} id={food.id} open={false}/>
             ))}
-            {showEmpty && (
+            {token && showEmpty && (
                 <EmptyState
                     message="No foods yet. Analyze an ingredient and save it to your library."
                     cta="Add your first food"
                     search="analysis/food-analysis"
                 />
             )}
-            {!showEmpty && <Button search={'analysis/food-analysis'}/>}
+            {token && !showEmpty && <Button search={'analysis/food-analysis'}/>}
         </Slide>
     );
 }

--- a/src/app/components/slider/slides/menu-slide.tsx
+++ b/src/app/components/slider/slides/menu-slide.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import MenuCard from '../../cards/menu-cards/menu-card';
 import Slide from './slide';
-import { SkeletonCard, EmptyState, useMinimumSkeletonTime } from '../slide-states';
+import { SkeletonCard, EmptyState, SignInPrompt, useMinimumSkeletonTime } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedMenu, RecipeWithServings, Recipe } from '@/app/types/types';
 
@@ -56,16 +56,17 @@ const MenuSlide = (): JSX.Element => {
 
     return (
         <Slide>
-            {showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
-            {!showSkeletons && menuList}
-            {showEmpty && (
+            {!token && <SignInPrompt kind="menus" />}
+            {token && showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
+            {token && !showSkeletons && menuList}
+            {token && showEmpty && (
                 <EmptyState
                     message="No menus yet. Group recipes into a menu to plan your meals."
                     cta="Create your first menu"
                     search="analysis/menu-analysis"
                 />
             )}
-            {!showEmpty && <Button search={'analysis/menu-analysis'}/>}
+            {token && !showEmpty && <Button search={'analysis/menu-analysis'}/>}
         </Slide>
     );
 }

--- a/src/app/components/slider/slides/recipe-slide.tsx
+++ b/src/app/components/slider/slides/recipe-slide.tsx
@@ -3,7 +3,7 @@ import useSWR from 'swr';
 import Button from '@/app/components/slider/button';
 import RecipeCard from '../../cards/recipe-cards/recipe-card';
 import Slide from './slide';
-import { SkeletonCard, EmptyState, useMinimumSkeletonTime } from '../slide-states';
+import { SkeletonCard, EmptyState, SignInPrompt, useMinimumSkeletonTime } from '../slide-states';
 import { AuthContext } from '@/app/context/auth-context';
 import { LoadedRecipe } from '@/app/types/types';
 
@@ -25,18 +25,19 @@ const RecipeSlide = (): JSX.Element => {
 
     return (
         <Slide>
-            {showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
-            {!showSkeletons && recipes.map((recipe, index) => (
+            {!token && <SignInPrompt kind="recipes" />}
+            {token && showSkeletons && Array.from({ length: 6 }, (_, i) => <SkeletonCard key={`s-${i}`} />)}
+            {token && !showSkeletons && recipes.map((recipe, index) => (
                 <RecipeCard recipe={recipe.recipe} image={recipe.image && `${recipe.image}`} index={index + 1} key={index + 1} id={recipe.id} open={false}/>
             ))}
-            {showEmpty && (
+            {token && showEmpty && (
                 <EmptyState
                     message="No recipes yet. Combine ingredients into a recipe you can reuse."
                     cta="Create your first recipe"
                     search="analysis/recipe-analysis"
                 />
             )}
-            {!showEmpty && <Button search={'analysis/recipe-analysis'}/>}
+            {token && !showEmpty && <Button search={'analysis/recipe-analysis'}/>}
         </Slide>
     );
 }


### PR DESCRIPTION
## Summary

- Add a ``SignInPrompt`` component to ``slide-states.tsx`` — same visual style as the empty-state card, with a **Sign in** CTA that links to ``/auth/basic_auth``.
- Each of the three slides (food/recipe/menu) renders the prompt when no auth token is present, replacing the previously-bare '+ Add' tile.
- The '+ Add' tile is hidden in the logged-out state so only one CTA is visible.

## Test plan

- [x] ``npm test`` — 47 suites / 119 tests
- [ ] Preview: log out (or open in a new incognito window) → each tab shows 'Sign in to see your foods/recipes/menus'
- [ ] Preview: click **Sign in** → lands on ``/auth/basic_auth``
- [ ] Preview: log back in → prompt disappears, real data (or skeletons then empty state) appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)