### PR TITLE
First-run tour: intro to Foods / Recipes / Menus

### DIFF
--- a/src/app/components/utilities/first-run-tour/first-run-tour.module.css
+++ b/src/app/components/utilities/first-run-tour/first-run-tour.module.css
@@ -1,0 +1,133 @@
+.backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 10;
+    background: rgba(0, 0, 0, 0.45);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    animation: fade_in 0.25s ease-out;
+}
+
+@keyframes fade_in {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes card_pop {
+    from { transform: translateY(12px) scale(0.98); opacity: 0; }
+    to { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+.card {
+    position: relative;
+    max-width: 460px;
+    width: 100%;
+    padding: 2.25rem 2rem 1.75rem;
+    border-radius: var(--radius-lg);
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: var(--shadow-lg);
+    animation: card_pop 0.35s cubic-bezier(0.34, 1.4, 0.64, 1);
+}
+
+.skip {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.9rem;
+    background: transparent;
+    border: none;
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: rgba(0, 0, 0, 0.45);
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    transition: color var(--transition);
+}
+
+.skip:hover {
+    color: rgba(0, 0, 0, 0.75);
+}
+
+.title {
+    margin: 0 0 0.5rem;
+    font-size: 1.4rem;
+    font-weight: 600;
+    color: #222;
+}
+
+.body {
+    margin: 0 0 1.5rem;
+    font-size: 0.95rem;
+    line-height: 1.5;
+    color: #555;
+}
+
+.dots {
+    display: flex;
+    gap: 0.4rem;
+    justify-content: center;
+    margin-bottom: 1.5rem;
+}
+
+.dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: rgba(0, 0, 0, 0.15);
+    transition: background var(--transition), width var(--transition);
+}
+
+.dot_active {
+    background: var(--primary-color);
+    width: 24px;
+    border-radius: 4px;
+}
+
+.actions {
+    display: flex;
+    gap: 0.6rem;
+    justify-content: flex-end;
+}
+
+.primary,
+.secondary {
+    height: 2.5rem;
+    padding: 0 1.25rem;
+    border-radius: var(--radius-sm);
+    font-size: 0.85rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color var(--transition);
+}
+
+.primary {
+    background: var(--primary-color);
+    color: white;
+    border: none;
+}
+
+.primary:hover {
+    background: var(--primary-darker-color);
+}
+
+.secondary {
+    background: white;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    color: #333;
+}
+
+.secondary:hover {
+    background: rgba(0, 0, 0, 0.04);
+}
+
+@media (max-width: 500px) {
+    .card {
+        padding: 2rem 1.5rem 1.5rem;
+    }
+
+    .title {
+        font-size: 1.2rem;
+    }
+}

--- a/src/app/components/utilities/first-run-tour/first-run-tour.tsx
+++ b/src/app/components/utilities/first-run-tour/first-run-tour.tsx
@@ -1,0 +1,89 @@
+'use client';
+import { useEffect, useState } from 'react';
+import styles from './first-run-tour.module.css';
+
+const STORAGE_KEY = 'nutrition_tour_seen_v1';
+
+interface Step {
+    title: string;
+    body: string;
+}
+
+const STEPS: Step[] = [
+    {
+        title: 'Welcome to Nutrition',
+        body: 'Track what you eat by building up a library of foods, recipes, and meal plans. Swipe between tabs to see each.',
+    },
+    {
+        title: 'Foods',
+        body: 'A single ingredient — an apple, a slice of bread, a spoonful of oil. Search, analyze the nutrients, and save it to your library for later.',
+    },
+    {
+        title: 'Recipes',
+        body: 'Multiple ingredients combined. Add foods with quantities and the total nutrients per serving are calculated for you.',
+    },
+    {
+        title: 'Menus',
+        body: 'A meal plan built from recipes (and optional extra ingredients). Great for weekly planning or tracking a full day.',
+    },
+];
+
+const FirstRunTour = (): JSX.Element | null => {
+    const [visible, setVisible] = useState(false);
+    const [step, setStep] = useState(0);
+
+    useEffect(() => {
+        try {
+            if (typeof window !== 'undefined' && !localStorage.getItem(STORAGE_KEY)) {
+                setVisible(true);
+            }
+        } catch {
+            // localStorage disabled — just skip the tour silently
+        }
+    }, []);
+
+    const dismiss = () => {
+        try {
+            localStorage.setItem(STORAGE_KEY, '1');
+        } catch {}
+        setVisible(false);
+    };
+
+    if (!visible) return null;
+
+    const current = STEPS[step];
+    const isLast = step === STEPS.length - 1;
+
+    return (
+        <div className={styles.backdrop} role="dialog" aria-modal="true" aria-labelledby="tour-title">
+            <div className={styles.card}>
+                <button className={styles.skip} onClick={dismiss} aria-label="Skip tour">Skip</button>
+                <h2 id="tour-title" className={styles.title}>{current.title}</h2>
+                <p className={styles.body}>{current.body}</p>
+
+                <div className={styles.dots}>
+                    {STEPS.map((_, i) => (
+                        <span
+                            key={i}
+                            className={i === step ? `${styles.dot} ${styles.dot_active}` : styles.dot}
+                        />
+                    ))}
+                </div>
+
+                <div className={styles.actions}>
+                    {step > 0 && (
+                        <button className={styles.secondary} onClick={() => setStep(step - 1)}>Back</button>
+                    )}
+                    {!isLast && (
+                        <button className={styles.primary} onClick={() => setStep(step + 1)}>Next</button>
+                    )}
+                    {isLast && (
+                        <button className={styles.primary} onClick={dismiss}>Get started</button>
+                    )}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default FirstRunTour;

--- a/src/app/components/utilities/first-run-tour/first-run-tour.tsx
+++ b/src/app/components/utilities/first-run-tour/first-run-tour.tsx
@@ -23,8 +23,8 @@ const STEPS: Step[] = [
         body: 'Multiple ingredients combined. Add foods with quantities and the total nutrients per serving are calculated for you.',
     },
     {
-        title: 'Menus',
-        body: 'A meal plan built from recipes (and optional extra ingredients). Great for weekly planning or tracking a full day.',
+        title: 'Meal plans',
+        body: 'A plan built from recipes (and optional extra ingredients). Great for weekly planning or tracking a full day.',
     },
 ];
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import MainNav from '@/app/components/navigation/main-nav';
 import NavBar from '@/app/components/navigation/nav-bar';
 import OpenCardMenu from '@/app/components/navigation/menus/opencard-menu';
 import Slider from '@/app/components/slider/slider';
+import FirstRunTour from './components/utilities/first-run-tour/first-run-tour';
 import { CardOpenContext } from './context/card-context';
 import { CardState } from './types/types';
 
@@ -29,6 +30,7 @@ export default function Home(): JSX.Element {
                 foodDeleted={deletedFood}
             />
             <Footer color="var(--primary-glass)" textColor="white" />
+            <FirstRunTour />
         </>
     );
 }


### PR DESCRIPTION
## Summary

Add a 4-step onboarding overlay to the home page that explains the app's mental model to new users:

1. **Welcome** — what the app does
2. **Foods** — single ingredients
3. **Recipes** — multiple ingredients combined
4. **Menus** — meal plans

Dismissal is persisted in ``localStorage`` under ``nutrition_tour_seen_v1`` so it only shows once per browser. The versioned key means we can re-show a revised tour later without touching other preferences.

## UX

- Full-screen dark backdrop with a centered card.
- **Skip** in the top-right dismisses immediately.
- **Back / Next** navigate between steps; last step shows **Get started**.
- Step indicator dots at the bottom, with the current step showing as an elongated bar.

## Test plan

- [x] ``npm test`` — 47 suites / 119 tests
- [ ] Preview: open the site in an incognito window → tour appears on the home page
- [ ] Preview: click through Next → Next → Next → Get started → tour dismisses, reload → does not appear again
- [ ] Preview: open in another incognito window → click Skip → tour dismisses, reload → does not appear again
- [ ] Preview: press ESC or click backdrop → currently these don't dismiss (only the buttons do); acceptable — can add if you want

🤖 Generated with [Claude Code](https://claude.com/claude-code)