### PR TITLE
Remove leftover Firebase CLI files

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,0 @@
-{
-  "projects": {
-    "default": "nutrition-3236d"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "jest",
-    "serve": "firebase emulators:start"
+    "test": "jest"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^6.4.2",


### PR DESCRIPTION
## Summary

- Delete ``.firebaserc`` — Firebase Hosting and Functions are retired; no CLI operations run from this repo. Firebase Storage still works because it uses the client SDK with ``firebase-config.json`` under ``src/server/``, not the CLI.
- Drop the ``serve`` npm script — it pointed at ``firebase emulators:start`` but ``functions/`` and ``firebase.json`` were removed earlier this session, so there's nothing to emulate.

The local ``.firebase/`` cache directory (already gitignored) was cleaned up outside this PR.

## Test plan

- [x] ``npm test`` — 47 suites / 119 tests
- [ ] Preview build succeeds (deps and scripts unchanged for production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)